### PR TITLE
Add custom database paths from CLI

### DIFF
--- a/wallaby/__init__.py
+++ b/wallaby/__init__.py
@@ -10,8 +10,8 @@ import pandas as pd
 
 _DEFAULT_SQLITE_PATH = "~/wallaby.db"
 
-class Wallaby:
 
+class Wallaby:
     def __init__(self, sqlite_database_path: str = _DEFAULT_SQLITE_PATH):
         """
         Create a new pointer to a Wallaby database.
@@ -28,7 +28,7 @@ class Wallaby:
             "jobtext": "TEXT",
             "tagscsv": "TEXT",
             "date": "FLOAT",
-            "results": "JSON"
+            "results": "JSON",
         }
         self._sqlite_database_path = os.path.expanduser(sqlite_database_path)
         self._conn = None
@@ -42,7 +42,6 @@ class Wallaby:
         results = self._cursor().execute(query, *args, **kwargs)
         self._conn.commit()
         return results
-
 
     def _initialize(self):
         """
@@ -65,26 +64,31 @@ class Wallaby:
         self._execute(new_table_cmd)
         return True
 
-    def log(self, results: Union[dict, str], tags: List[str] = None, jobtext: str = None):
+    def log(
+        self, results: Union[dict, str], tags: List[str] = None, jobtext: str = None
+    ):
         jobtext = jobtext or " ".join(sys.argv[:])
         tagscsv = "," + (",".join(tags) if tags else "") + ","
         date = time.time()
         if isinstance(results, str):
             results = {"output": results}
         results = json.dumps(results)
-        self._execute("""
+        self._execute(
+            """
             INSERT INTO
                 results(jobtext, tagscsv, date, results)
             VALUES(?, ?, ?, ?)
-        """, (jobtext, tagscsv, date, results))
+        """,
+            (jobtext, tagscsv, date, results),
+        )
         return True
 
     def get_by_tag(
-            self,
-            all_of: Union[List[str], str] = None,
-            any_of: Union[List[str], str] = None,
-            as_dataframe: bool = False
-        ) -> List[tuple]:
+        self,
+        all_of: Union[List[str], str] = None,
+        any_of: Union[List[str], str] = None,
+        as_dataframe: bool = False,
+    ) -> List[tuple]:
         """
         Query for a list of results based upon the tag.
 
@@ -111,15 +115,19 @@ class Wallaby:
         if isinstance(taglist, str):
             taglist = [taglist]
         tag_clause = set_operation.join([f"tagscsv LIKE '%,{t},%'" for t in taglist])
-        results = self._execute(f"""
+        results = self._execute(
+            f"""
             SELECT * FROM results WHERE {tag_clause}
-        """).fetchall()
+        """
+        ).fetchall()
         if as_dataframe:
             return pd.DataFrame(results, columns=["id", *self._columns.keys()])
         else:
             return results
 
-    def get_results_since(self, since: float, as_dataframe: bool = False) -> List[tuple]:
+    def get_results_since(
+        self, since: float, as_dataframe: bool = False
+    ) -> List[tuple]:
         """
         Get all results since a timestamp.
 
@@ -131,14 +139,16 @@ class Wallaby:
             List[tuple]: A list of SQL rows
 
         """
-        results = self._execute("""
+        results = self._execute(
+            """
             SELECT * FROM results WHERE date > (?)
-        """, (since,)).fetchall()
+        """,
+            (since,),
+        ).fetchall()
         if as_dataframe:
             return pd.DataFrame(results, columns=["id", *self._columns.keys()])
         else:
             return results
-
 
     def raw_query(self, query: str, as_dataframe: bool = False) -> List[tuple]:
         """
@@ -160,7 +170,6 @@ class Wallaby:
             return results
 
 
-
 def cli():
     """
     The command-line version of Wallaby. See Readme for usage.
@@ -170,8 +179,9 @@ def cli():
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-c","--command", default="")
-    parser.add_argument("-t","--tags", default="")
+    parser.add_argument("-c", "--command", default="")
+    parser.add_argument("-t", "--tags", default="")
+    parser.add_argument("-f", "--database-file", default=_DEFAULT_SQLITE_PATH)
     args = parser.parse_args()
 
     environment = dict(os.environ)
@@ -183,8 +193,7 @@ def cli():
 
     if args.command:
         p = subprocess.check_output(
-            args.command, shell=True, env=environment,
-            input=stdin
+            args.command, shell=True, env=environment, input=stdin
         )
         output = p.decode()
     else:
@@ -194,12 +203,12 @@ def cli():
     result = {
         "environment": environment,
         "output": output,
-        "command": args.command or None
+        "command": args.command or None,
     }
 
     other_tags = args.tags.split(",") if args.tags else []
 
-    w = Wallaby()
+    w = Wallaby(args.database_file)
     w.log(result, tags=["cli", *other_tags], jobtext=args.command or None)
     print(output, end="")
 
@@ -213,16 +222,20 @@ def wallaby2json():
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-t","--all-tags", default="")
-    parser.add_argument("-e","--include-env", default=False, action='store_true')
+    parser.add_argument("-t", "--all-tags", default="")
+    parser.add_argument("-e", "--include-env", default=False, action="store_true")
+    parser.add_argument("-f", "--database-file", default=_DEFAULT_SQLITE_PATH)
     args = parser.parse_args()
 
-    w = Wallaby()
+    w = Wallaby(args.database_file)
     all_tags = args.all_tags.split(",")
     res = w.get_by_tag(all_of=all_tags, as_dataframe=True)
     res.results = res.results.map(lambda x: json.loads(x))
     res = res.join(pd.json_normalize(res.results))
     res.drop(columns="results", inplace=True)
     if not args.include_env:
-        res.drop(columns=[col for col in res.columns if col.startswith("environment.")], inplace=True)
+        res.drop(
+            columns=[col for col in res.columns if col.startswith("environment.")],
+            inplace=True,
+        )
     print(res.to_json())


### PR DESCRIPTION
You can now pass a custom path to a wallaby database with the `-f` flag:

```shell
wallaby -f my-database.db --command "echo hi"

# same as:
wallaby --database-file my-database.db --command "echo hi"
```